### PR TITLE
add native resolution to games

### DIFF
--- a/src/lindbergh/config.c
+++ b/src/lindbergh/config.c
@@ -479,10 +479,12 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0018-SDX";
         config.gameID = "SBMN";
         config.gameReleaseYear = "2006 ?";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1280x768";
         config.gameStatus = WORKING;
         config.jvsIOType = SEGA_TYPE_1;
         config.gameType = ABC;
+        config.width = 1280;
+        config.height = 768;
         return 0;
     }
     break;
@@ -493,10 +495,12 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0018A-SDX";
         config.gameID = "SBMN";
         config.gameReleaseYear = "2006 ?";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1280x768";
         config.gameStatus = WORKING;
         config.jvsIOType = SEGA_TYPE_1;
         config.gameType = ABC;
+        config.width = 1280;
+        config.height = 768;
         return 0;
     }
     break;

--- a/src/lindbergh/config.c
+++ b/src/lindbergh/config.c
@@ -85,9 +85,11 @@ static int detectGame(uint32_t elf_crc)
         config.gameID = "SBLC";
         config.gameDVP = "DVP-0003A";
         config.gameReleaseYear = "2005";
-        config.gameNativeResolutions = "1280x768";
+        config.gameNativeResolutions = "640x480, 1280x768";
         config.gameType = SHOOTING;
         config.gameStatus = WORKING;
+        config.width = 1280;
+        config.height = 768;
         return 0;
     }
     break;
@@ -99,9 +101,11 @@ static int detectGame(uint32_t elf_crc)
         config.gameID = "SBLC";
         config.gameDVP = "DVP-0003B";
         config.gameReleaseYear = "2005";
-        config.gameNativeResolutions = "1280x768";
+        config.gameNativeResolutions = "640x480, 1280x768";
         config.gameType = SHOOTING;
         config.gameStatus = WORKING;
+        config.width = 1280;
+        config.height = 768;
         return 0;
     }
     break;
@@ -113,9 +117,11 @@ static int detectGame(uint32_t elf_crc)
         config.gameID = "SBLC";
         config.gameDVP = "DVP-0003C";
         config.gameReleaseYear = "2005";
-        config.gameNativeResolutions = "1280x768";
+        config.gameNativeResolutions = "640x480, 1280x768";
         config.gameType = SHOOTING;
         config.gameStatus = WORKING;
+        config.width = 1280;
+        config.height = 768;
         return 0;
     }
     break;
@@ -165,6 +171,8 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0063";
         config.gameReleaseYear = "2008";
         config.gameNativeResolutions = "1280x768";
+        config.width = 1280;
+        config.height = 768;
         return 0;
     }
     break;
@@ -182,6 +190,8 @@ static int detectGame(uint32_t elf_crc)
         config.emulateMotionboard = 1;
         config.gameStatus = WORKING;
         config.gameType = DRIVING;
+        config.width = 800;
+        config.height = 480;
         return 0;
     }
     break;
@@ -198,6 +208,8 @@ static int detectGame(uint32_t elf_crc)
         config.emulateMotionboard = 1;
         config.gameStatus = WORKING;
         config.gameType = DRIVING;
+        config.width = 800;
+        config.height = 480;
         return 0;
     }
     break;
@@ -211,6 +223,8 @@ static int detectGame(uint32_t elf_crc)
         config.gameNativeResolutions = "1280x768";
         config.gameStatus = WORKING;
         config.gameType = FIGHTING;
+        config.width = 1280;
+        config.height = 768;
         return 0;
     }
     break;
@@ -224,6 +238,8 @@ static int detectGame(uint32_t elf_crc)
         config.gameNativeResolutions = "1280x768";
         config.gameStatus = WORKING;
         config.gameType = FIGHTING;
+        config.width = 1280;
+        config.height = 768;
         return 0;
     }
     break;
@@ -237,6 +253,8 @@ static int detectGame(uint32_t elf_crc)
         config.gameNativeResolutions = "1280x768";
         config.gameStatus = WORKING;
         config.gameType = FIGHTING;
+        config.width = 1280;
+        config.height = 768;
         return 0;
     }
     break;
@@ -250,6 +268,8 @@ static int detectGame(uint32_t elf_crc)
         config.gameNativeResolutions = "1280x768";
         config.gameStatus = WORKING;
         config.gameType = FIGHTING;
+        config.width = 1280;
+        config.height = 768;
         return 0;
     }
     break;
@@ -263,6 +283,8 @@ static int detectGame(uint32_t elf_crc)
         config.gameNativeResolutions = "1280x768";
         config.gameStatus = WORKING;
         config.gameType = FIGHTING;
+        config.width = 1280;
+        config.height = 768;
         return 0;
     }
     break;
@@ -276,6 +298,8 @@ static int detectGame(uint32_t elf_crc)
         config.gameNativeResolutions = "1280x768";
         config.gameStatus = WORKING;
         config.gameType = FIGHTING;
+        config.width = 1280;
+        config.height = 768;
         return 0;
     }
     break;
@@ -289,6 +313,8 @@ static int detectGame(uint32_t elf_crc)
         config.gameNativeResolutions = "1280x768";
         config.gameStatus = WORKING;
         config.gameType = FIGHTING;
+        config.width = 1280;
+        config.height = 768;
         return 0;
     }
     break;
@@ -302,6 +328,8 @@ static int detectGame(uint32_t elf_crc)
         config.gameNativeResolutions = "1280x768";
         config.gameStatus = WORKING;
         config.gameType = FIGHTING;
+        config.width = 1280;
+        config.height = 768;
         return 0;
     }
     break;
@@ -315,6 +343,8 @@ static int detectGame(uint32_t elf_crc)
         config.gameNativeResolutions = "1280x768";
         config.gameType = FIGHTING;
         config.gameStatus = WORKING;
+        config.width = 1280;
+        config.height = 768;
         return 0;
     }
     break;
@@ -328,6 +358,8 @@ static int detectGame(uint32_t elf_crc)
         config.gameNativeResolutions = "1280x768";
         config.gameType = FIGHTING;
         config.gameStatus = WORKING;
+        config.width = 1280;
+        config.height = 768;
         return 0;
     }
     break;
@@ -341,6 +373,8 @@ static int detectGame(uint32_t elf_crc)
         config.gameNativeResolutions = "1280x768";
         config.gameType = FIGHTING;
         config.gameStatus = WORKING;
+        config.width = 1280;
+        config.height = 768;
         return 0;
     }
     break;
@@ -354,6 +388,8 @@ static int detectGame(uint32_t elf_crc)
         config.gameNativeResolutions = "1280x768";
         config.gameType = FIGHTING;
         config.gameStatus = WORKING;
+        config.width = 1280;
+        config.height = 768;
         return 0;
     }
     break;
@@ -399,6 +435,8 @@ static int detectGame(uint32_t elf_crc)
         config.gameStatus = WORKING;
         config.jvsIOType = SEGA_TYPE_1;
         config.gameType = ABC;
+        config.width = 640;
+        config.height = 480;
         return 0;
     }
     break;
@@ -413,6 +451,8 @@ static int detectGame(uint32_t elf_crc)
         config.gameStatus = WORKING;
         config.jvsIOType = SEGA_TYPE_1;
         config.gameType = ABC;
+        config.width = 640;
+        config.height = 480;
         return 0;
     }
     break;
@@ -427,6 +467,8 @@ static int detectGame(uint32_t elf_crc)
         config.gameStatus = WORKING;
         config.jvsIOType = SEGA_TYPE_1;
         config.gameType = ABC;
+        config.width = 640;
+        config.height = 480;
         return 0;
     }
     break;
@@ -465,7 +507,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0031";
         config.gameID = "SBLR";
         config.gameReleaseYear = "2006 ?";
-        config.gameNativeResolutions = "640x480";
+        config.gameNativeResolutions = "";
         config.gameStatus = WORKING;
         config.jvsIOType = SEGA_TYPE_1;
         config.gameType = ABC;
@@ -479,7 +521,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0031A";
         config.gameID = "SBLR";
         config.gameReleaseYear = "2006 ?";
-        config.gameNativeResolutions = "640x480";
+        config.gameNativeResolutions = "";
         config.gameStatus = WORKING;
         config.jvsIOType = SEGA_TYPE_1;
         config.gameType = ABC;
@@ -496,6 +538,8 @@ static int detectGame(uint32_t elf_crc)
         config.gameNativeResolutions = "1360x768";
         config.gameStatus = WORKING;
         config.gameType = DRIVING;
+        config.width = 1360;
+        config.height = 768;
         return 0;
     }
     break;
@@ -509,6 +553,8 @@ static int detectGame(uint32_t elf_crc)
         config.gameNativeResolutions = "1360x768";
         config.gameStatus = WORKING;
         config.gameType = DRIVING;
+        config.width = 1360;
+        config.height = 768;
         return 0;
     }
     break;
@@ -522,6 +568,8 @@ static int detectGame(uint32_t elf_crc)
         config.gameNativeResolutions = "1360x768";
         config.gameStatus = WORKING;
         config.gameType = DRIVING;
+        config.width = 1360;
+        config.height = 768;
         return 0;
     }
     break;
@@ -535,6 +583,8 @@ static int detectGame(uint32_t elf_crc)
         config.gameNativeResolutions = "1360x768";
         config.gameStatus = WORKING;
         config.gameType = DRIVING;
+        config.width = 1360;
+        config.height = 768;
         return 0;
     }
     break;
@@ -548,6 +598,8 @@ static int detectGame(uint32_t elf_crc)
         config.gameNativeResolutions = "1360x768";
         config.gameStatus = WORKING;
         config.gameType = DRIVING;
+        config.width = 1360;
+        config.height = 768;
         return 0;
     }
     break;
@@ -561,6 +613,8 @@ static int detectGame(uint32_t elf_crc)
         config.gameNativeResolutions = "1360x768";
         config.gameStatus = WORKING;
         config.gameType = DRIVING;
+        config.width = 1360;
+        config.height = 768;
         return 0;
     }
     break;
@@ -574,6 +628,8 @@ static int detectGame(uint32_t elf_crc)
         config.gameNativeResolutions = "1360x768";
         config.gameStatus = WORKING;
         config.gameType = DRIVING;
+        config.width = 1360;
+        config.height = 768;
         return 0;
     }
     break;
@@ -587,6 +643,8 @@ static int detectGame(uint32_t elf_crc)
         config.gameNativeResolutions = "1360x768";
         config.gameStatus = WORKING;
         config.gameType = DRIVING;
+        config.width = 1360;
+        config.height = 768;
         return 0;
     }
     break;
@@ -601,8 +659,8 @@ static int detectGame(uint32_t elf_crc)
         config.gameNativeResolutions = "640x480";
         config.gameStatus = WORKING;
         config.gameType = DRIVING;
-        config.width = 1280;
-        config.height = 768;
+        config.width = 640;
+        config.height = 480;
         return 0;
     }
     break;
@@ -613,10 +671,12 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0069";
         config.gameID = "SBQL";
         config.gameReleaseYear = "2008";
-        config.gameNativeResolutions = "1360x768";
+        config.gameNativeResolutions = "640x480, 1360x768";
         config.gameLindberghColour = REDEX;
         config.gameType = SHOOTING;
         config.gameStatus = WORKING;
+        config.width = 1360;
+        config.height = 768;
         return 0;
     }
     break;
@@ -631,6 +691,8 @@ static int detectGame(uint32_t elf_crc)
         config.emulateDriveboard = 1;
         config.gameStatus = WORKING;
         config.gameType = DRIVING;
+        config.width = 640;
+        config.height = 480;
         return 0;
     }
     break;
@@ -642,10 +704,12 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0027A";
         config.gameID = "SBMV";
         config.gameReleaseYear = "2008";
-        config.gameNativeResolutions = "1280x768";
+        config.gameNativeResolutions = "640x480, 1280x768";
         config.gameLindberghColour = RED;
         config.gameStatus = WORKING;
         config.gameType = SHOOTING;
+        config.width = 1280;
+        config.height = 768;
         return 0;
     }
     break;
@@ -657,8 +721,10 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0005";
         config.gameID = "SBKX";
         config.gameReleaseYear = "2006";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "640x480, 1360x768";
         config.gameStatus = WORKING;
+        config.width = 1360;
+        config.height = 768;
         return 0;
     }
     break;
@@ -670,9 +736,11 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0005A";
         config.gameID = "SBKX";
         config.gameReleaseYear = "2006";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "640x480, 1360x768";
         config.gameType = FIGHTING;
         config.gameStatus = WORKING;
+        config.width = 1360;
+        config.height = 768;
         return 0;
     }
     break;
@@ -684,9 +752,11 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0005B";
         config.gameID = "SBKX";
         config.gameReleaseYear = "2006";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "640x480, 1360x768";
         config.gameType = FIGHTING;
         config.gameStatus = WORKING;
+        config.width = 1360;
+        config.height = 768;
         return 0;
     }
     break;
@@ -698,9 +768,11 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0005C";
         config.gameID = "SBKX";
         config.gameReleaseYear = "2006";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "640x480, 1360x768";
         config.gameType = FIGHTING;
         config.gameStatus = WORKING;
+        config.width = 1360;
+        config.height = 768;
         return 0;
     }
     break;
@@ -715,6 +787,8 @@ static int detectGame(uint32_t elf_crc)
         config.gameLindberghColour = RED;
         config.gameStatus = WORKING;
         config.gameType = SHOOTING;
+        config.width = 640;
+        config.height = 480;
         return 0;
     }
     break;
@@ -730,6 +804,8 @@ static int detectGame(uint32_t elf_crc)
         config.gameLindberghColour = RED;
         config.gameType = SHOOTING;
         config.jvsIOType = SEGA_TYPE_1;
+        config.width = 640;
+        config.height = 480;
         return 0;
     }
     break;
@@ -743,6 +819,8 @@ static int detectGame(uint32_t elf_crc)
         config.gameNativeResolutions = "1360x768";
         config.gameStatus = WORKING;
         config.gameType = DRIVING;
+        config.width = 1360;
+        config.height = 768;
         return 0;
     }
     break;
@@ -756,6 +834,8 @@ static int detectGame(uint32_t elf_crc)
         config.gameNativeResolutions = "1360x768";
         config.gameStatus = WORKING;
         config.gameType = DRIVING;
+        config.width = 1360;
+        config.height = 768;
         return 0;
     }
     break;
@@ -769,6 +849,8 @@ static int detectGame(uint32_t elf_crc)
         config.gameReleaseYear = "2009";
         config.gameNativeResolutions = "1360x768";
         config.gameType = DRIVING;
+        config.width = 1360;
+        config.height = 768;
         return 0;
     }
     break;
@@ -782,6 +864,8 @@ static int detectGame(uint32_t elf_crc)
         config.gameNativeResolutions = "1360x768";
         config.gameStatus = WORKING;
         config.gameType = DRIVING;
+        config.width = 1360;
+        config.height = 768;
         return 0;
     }
     break;
@@ -795,6 +879,8 @@ static int detectGame(uint32_t elf_crc)
         config.gameNativeResolutions = "1280x768";
         config.gameType = DRIVING;
         config.gameStatus = WORKING;
+        config.width = 1280;
+        config.height = 768;
         return 0;
     }
     break;
@@ -805,7 +891,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameID = "SBST";
         config.gameDVP = "DVP-0057";
         config.gameReleaseYear = "2008";
-        config.gameNativeResolutions = "1280x768";
+        config.gameNativeResolutions = "";
         config.gameType = DRIVING;
         config.gameStatus = WORKING;
         return 0;
@@ -818,7 +904,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameID = "SBST";
         config.gameDVP = "DVP-0079";
         config.gameReleaseYear = "2009";
-        config.gameNativeResolutions = "1280x768";
+        config.gameNativeResolutions = "";
         config.gameType = DRIVING;
         config.gameStatus = WORKING;
         return 0;
@@ -863,6 +949,8 @@ static int detectGame(uint32_t elf_crc)
         config.gameLindberghColour = RED;
         config.gameType = HARLEY;
         config.gameStatus = WORKING;
+        config.width = 1360;
+        config.height = 768;
         return 0;
     }
     break;

--- a/src/lindbergh/config.c
+++ b/src/lindbergh/config.c
@@ -437,7 +437,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0018-SDX";
         config.gameID = "SBMN";
         config.gameReleaseYear = "2006 ?";
-        config.gameNativeResolutions = "640x480";
+        config.gameNativeResolutions = "";
         config.gameStatus = WORKING;
         config.jvsIOType = SEGA_TYPE_1;
         config.gameType = ABC;
@@ -451,7 +451,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0018A-SDX";
         config.gameID = "SBMN";
         config.gameReleaseYear = "2006 ?";
-        config.gameNativeResolutions = "640x480";
+        config.gameNativeResolutions = "";
         config.gameStatus = WORKING;
         config.jvsIOType = SEGA_TYPE_1;
         config.gameType = ABC;

--- a/src/lindbergh/config.c
+++ b/src/lindbergh/config.c
@@ -85,7 +85,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameID = "SBLC";
         config.gameDVP = "DVP-0003A";
         config.gameReleaseYear = "2005";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1280x768";
         config.gameType = SHOOTING;
         config.gameStatus = WORKING;
         return 0;
@@ -99,7 +99,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameID = "SBLC";
         config.gameDVP = "DVP-0003B";
         config.gameReleaseYear = "2005";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1280x768";
         config.gameType = SHOOTING;
         config.gameStatus = WORKING;
         return 0;
@@ -113,7 +113,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameID = "SBLC";
         config.gameDVP = "DVP-0003C";
         config.gameReleaseYear = "2005";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1280x768";
         config.gameType = SHOOTING;
         config.gameStatus = WORKING;
         return 0;
@@ -128,7 +128,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameID = "SBLS";
         config.gameDVP = "DVP-0010";
         config.gameReleaseYear = "2006";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1024x768";
         config.gameStatus = WORKING;
         config.gameType = SHOOTING;
         config.width = 1024;
@@ -145,7 +145,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameID = "SBLS";
         config.gameDVP = "DVP-0010B";
         config.gameReleaseYear = "2006";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1024x768";
         config.gameStatus = WORKING;
         config.gameType = SHOOTING;
         config.width = 1024;
@@ -164,7 +164,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameID = "SBRC";
         config.gameDVP = "DVP-0063";
         config.gameReleaseYear = "2008";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1280x768";
         return 0;
     }
     break;
@@ -177,7 +177,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0015A";
         config.gameID = "SBMB";
         config.gameReleaseYear = "2006";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "800x480";
         config.emulateDriveboard = 1;
         config.emulateMotionboard = 1;
         config.gameStatus = WORKING;
@@ -193,7 +193,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0015";
         config.gameID = "SBMB";
         config.gameReleaseYear = "2006";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "800x480";
         config.emulateDriveboard = 1;
         config.emulateMotionboard = 1;
         config.gameStatus = WORKING;
@@ -208,7 +208,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0008";
         config.gameID = "SBLM";
         config.gameReleaseYear = "2005";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1280x768";
         config.gameStatus = WORKING;
         config.gameType = FIGHTING;
         return 0;
@@ -221,7 +221,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0008A";
         config.gameID = "SBLM";
         config.gameReleaseYear = "2005";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1280x768";
         config.gameStatus = WORKING;
         config.gameType = FIGHTING;
         return 0;
@@ -234,7 +234,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0008B";
         config.gameID = "SBLM";
         config.gameReleaseYear = "2005";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1280x768";
         config.gameStatus = WORKING;
         config.gameType = FIGHTING;
         return 0;
@@ -247,7 +247,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0008E";
         config.gameID = "SBLM";
         config.gameReleaseYear = "2005";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1280x768";
         config.gameStatus = WORKING;
         config.gameType = FIGHTING;
         return 0;
@@ -260,7 +260,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0043";
         config.gameID = "SBLM";
         config.gameReleaseYear = "2005";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1280x768";
         config.gameStatus = WORKING;
         config.gameType = FIGHTING;
         return 0;
@@ -273,7 +273,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-XXXX";
         config.gameID = "SBQU";
         config.gameReleaseYear = "2008";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1280x768";
         config.gameStatus = WORKING;
         config.gameType = FIGHTING;
         return 0;
@@ -286,7 +286,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-XXXX";
         config.gameID = "SBQU";
         config.gameReleaseYear = "2008";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1280x768";
         config.gameStatus = WORKING;
         config.gameType = FIGHTING;
         return 0;
@@ -299,7 +299,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-XXXX";
         config.gameID = "SBQU";
         config.gameReleaseYear = "2008";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1280x768";
         config.gameStatus = WORKING;
         config.gameType = FIGHTING;
         return 0;
@@ -312,7 +312,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-SBUV";
         config.gameID = "SBUV";
         config.gameReleaseYear = "2010";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1280x768";
         config.gameType = FIGHTING;
         config.gameStatus = WORKING;
         return 0;
@@ -325,7 +325,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-5019A";
         config.gameID = "SBUV";
         config.gameReleaseYear = "2010";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1280x768";
         config.gameType = FIGHTING;
         config.gameStatus = WORKING;
         return 0;
@@ -338,7 +338,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-5019B";
         config.gameID = "SBUV";
         config.gameReleaseYear = "2010";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1280x768";
         config.gameType = FIGHTING;
         config.gameStatus = WORKING;
         return 0;
@@ -351,7 +351,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-5020";
         config.gameID = "SBUV";
         config.gameReleaseYear = "2010";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1280x768";
         config.gameType = FIGHTING;
         config.gameStatus = WORKING;
         return 0;
@@ -364,7 +364,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0011";
         config.gameID = "SBLU";
         config.gameReleaseYear = "2006";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1360x768";
         config.gameType = SHOOTING;
         config.gameStatus = WORKING;
         config.width = 1360;
@@ -380,7 +380,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameID = "SBNR";
         config.gameDVP = "DVP-0036";
         config.gameReleaseYear = "2007";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1024x768";
         config.gameType = SHOOTING;
         config.gameStatus = WORKING;
         config.width = 1024;
@@ -395,7 +395,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0009";
         config.gameID = "SBLR";
         config.gameReleaseYear = "2006";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "640x480";
         config.gameStatus = WORKING;
         config.jvsIOType = SEGA_TYPE_1;
         config.gameType = ABC;
@@ -409,7 +409,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0009A";
         config.gameID = "SBLR";
         config.gameReleaseYear = "2006";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "640x480";
         config.gameStatus = WORKING;
         config.jvsIOType = SEGA_TYPE_1;
         config.gameType = ABC;
@@ -423,7 +423,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0009B";
         config.gameID = "SBLR";
         config.gameReleaseYear = "2006";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "640x480";
         config.gameStatus = WORKING;
         config.jvsIOType = SEGA_TYPE_1;
         config.gameType = ABC;
@@ -437,7 +437,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0018-SDX";
         config.gameID = "SBMN";
         config.gameReleaseYear = "2006 ?";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "640x480";
         config.gameStatus = WORKING;
         config.jvsIOType = SEGA_TYPE_1;
         config.gameType = ABC;
@@ -451,7 +451,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0018A-SDX";
         config.gameID = "SBMN";
         config.gameReleaseYear = "2006 ?";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "640x480";
         config.gameStatus = WORKING;
         config.jvsIOType = SEGA_TYPE_1;
         config.gameType = ABC;
@@ -465,7 +465,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0031";
         config.gameID = "SBLR";
         config.gameReleaseYear = "2006 ?";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "640x480";
         config.gameStatus = WORKING;
         config.jvsIOType = SEGA_TYPE_1;
         config.gameType = ABC;
@@ -479,7 +479,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0031A";
         config.gameID = "SBLR";
         config.gameReleaseYear = "2006 ?";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "640x480";
         config.gameStatus = WORKING;
         config.jvsIOType = SEGA_TYPE_1;
         config.gameType = ABC;
@@ -493,7 +493,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameID = "SBML";
         config.gameDVP = "DVP-0019A";
         config.gameReleaseYear = "2007";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1360x768";
         config.gameStatus = WORKING;
         config.gameType = DRIVING;
         return 0;
@@ -506,7 +506,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameID = "SBML";
         config.gameDVP = "DVP-0019B";
         config.gameReleaseYear = "2007";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1360x768";
         config.gameStatus = WORKING;
         config.gameType = DRIVING;
         return 0;
@@ -519,7 +519,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameID = "SBML";
         config.gameDVP = "DVP-0019C";
         config.gameReleaseYear = "2007";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1360x768";
         config.gameStatus = WORKING;
         config.gameType = DRIVING;
         return 0;
@@ -532,7 +532,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameID = "SBML";
         config.gameDVP = "DVP-0019D";
         config.gameReleaseYear = "2007";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1360x768";
         config.gameStatus = WORKING;
         config.gameType = DRIVING;
         return 0;
@@ -545,7 +545,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameID = "SBML";
         config.gameDVP = "DVP-0019G";
         config.gameReleaseYear = "2007";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1360x768";
         config.gameStatus = WORKING;
         config.gameType = DRIVING;
         return 0;
@@ -558,7 +558,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameID = "SBNK";
         config.gameDVP = "DVP-0030B";
         config.gameReleaseYear = "2007";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1360x768";
         config.gameStatus = WORKING;
         config.gameType = DRIVING;
         return 0;
@@ -571,7 +571,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameID = "SBNK";
         config.gameDVP = "DVP-0030C";
         config.gameReleaseYear = "2007";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1360x768";
         config.gameStatus = WORKING;
         config.gameType = DRIVING;
         return 0;
@@ -584,7 +584,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameID = "SBNK";
         config.gameDVP = "DVP-0030D";
         config.gameReleaseYear = "2007";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1360x768";
         config.gameStatus = WORKING;
         config.gameType = DRIVING;
         return 0;
@@ -598,7 +598,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0044";
         config.gameID = "SBPF";
         config.gameReleaseYear = "2008";
-        config.gameNativeResolutions = "1280x768";
+        config.gameNativeResolutions = "640x480";
         config.gameStatus = WORKING;
         config.gameType = DRIVING;
         config.width = 1280;
@@ -613,7 +613,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0069";
         config.gameID = "SBQL";
         config.gameReleaseYear = "2008";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1360x768";
         config.gameLindberghColour = REDEX;
         config.gameType = SHOOTING;
         config.gameStatus = WORKING;
@@ -627,7 +627,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0060";
         config.gameID = "SBQW";
         config.gameReleaseYear = "2008";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "640x480";
         config.emulateDriveboard = 1;
         config.gameStatus = WORKING;
         config.gameType = DRIVING;
@@ -642,7 +642,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0027A";
         config.gameID = "SBMV";
         config.gameReleaseYear = "2008";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1280x768";
         config.gameLindberghColour = RED;
         config.gameStatus = WORKING;
         config.gameType = SHOOTING;
@@ -711,7 +711,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0048A";
         config.gameID = "SBPP";
         config.gameReleaseYear = "2008";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "640x480";
         config.gameLindberghColour = RED;
         config.gameStatus = WORKING;
         config.gameType = SHOOTING;
@@ -726,7 +726,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0029A";
         config.gameID = "SBNJ";
         config.gameReleaseYear = "2007";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "640x480";
         config.gameLindberghColour = RED;
         config.gameType = SHOOTING;
         config.jvsIOType = SEGA_TYPE_1;
@@ -740,7 +740,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0070A";
         config.gameID = "SBQZ";
         config.gameReleaseYear = "2009";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1360x768";
         config.gameStatus = WORKING;
         config.gameType = DRIVING;
         return 0;
@@ -753,7 +753,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0070F";
         config.gameID = "SBQZ";
         config.gameReleaseYear = "2009";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1360x768";
         config.gameStatus = WORKING;
         config.gameType = DRIVING;
         return 0;
@@ -767,7 +767,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0075";
         config.gameID = "SBTS";
         config.gameReleaseYear = "2009";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1360x768";
         config.gameType = DRIVING;
         return 0;
     }
@@ -779,7 +779,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0084A";
         config.gameID = "SBQN";
         config.gameReleaseYear = "2009";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1360x768";
         config.gameStatus = WORKING;
         config.gameType = DRIVING;
         return 0;
@@ -792,7 +792,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameID = "SBQN";
         config.gameDVP = "DVP-0057B";
         config.gameReleaseYear = "2008";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1280x768";
         config.gameType = DRIVING;
         config.gameStatus = WORKING;
         return 0;
@@ -805,7 +805,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameID = "SBST";
         config.gameDVP = "DVP-0057";
         config.gameReleaseYear = "2008";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1280x768";
         config.gameType = DRIVING;
         config.gameStatus = WORKING;
         return 0;
@@ -818,7 +818,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameID = "SBST";
         config.gameDVP = "DVP-0079";
         config.gameReleaseYear = "2009";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1280x768";
         config.gameType = DRIVING;
         config.gameStatus = WORKING;
         return 0;
@@ -831,7 +831,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameID = "SBST";
         config.gameDVP = "DVP-0083";
         config.gameReleaseYear = "2009";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1280x768";
         config.gameType = DRIVING;
         config.gameStatus = WORKING;
         return 0;
@@ -844,7 +844,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-0011A";
         config.gameID = "SBLU";
         config.gameReleaseYear = "2006";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1360x768";
         config.gameType = SHOOTING;
         config.gameStatus = WORKING;
         config.width = 1360;
@@ -859,7 +859,7 @@ static int detectGame(uint32_t elf_crc)
         config.gameDVP = "DVP-5007";
         config.gameID = "SBRG";
         config.gameReleaseYear = "2009";
-        config.gameNativeResolutions = "";
+        config.gameNativeResolutions = "1360x768";
         config.gameLindberghColour = RED;
         config.gameType = HARLEY;
         config.gameStatus = WORKING;


### PR DESCRIPTION
This is an effort to add a bit more documentation about native resolution of all known games. I've checked every Lindbergh cabinet games manual I could find. There's always a page for the dip switchs and output video resolution. Thanks to Sega Retro website, I could find most of them, the rest are on the Internet Archive and some current Amusement Park still active as of today.

Lindbergh (yellow, red, blue) had the same display dip switches shown as such in their manual (Red model, [US](https://segaretro.org/images/e/ef/LindberghRed_Manual.pdf), p.8 / Yellow model, [JP](https://segaretro.org/images/1/19/Lindbergh_Manual_JP.pdf), p8):

![image](https://github.com/user-attachments/assets/2edb36aa-b944-48e5-9c81-3e9a435cb2cf)

As you can see, only switches 4 to 6 are used for resolution. From this, I've spent some time reading manuals of each cabinet and even compared in between (standard, deluxe, super deluxe; US, UK, JP). There was one difference between SDX and the rest (e.g: After Burner Climax). Perhaps there is a difference between revisions, but I'm unsure about this. 

I'm missing information for some games. For example, I couldn't find HummerEE indication on the dip switches. I wasn't able to find any owner's manual for Initial D Arcade Stage 5. I just assumed their native resolution following the fact that both were released after their predecessor which had 1360x768 res already. Some games had support for both 4:3 and non-4:3 resolutions depending on the monitor used, but I only focused on the highest res available in the PR. Here's the list:

**2 Spicy**
640x480 and 1280x768 ([US, p.16](https://segaretro.org/images/b/b6/2Spicy_Lindbergh_Manual.pdf)) ([JP, p.104](https://archive.org/details/2-too-spicy-1/page/104/mode/2up))

**After Burner Climax**
640x480 ([US-DX, p.18](https://segaretro.org/images/4/40/AfterBurnerClimax_Lindbergh_Manual_Deluxe.pdf)) ([UK-STD, p.48](https://wwyss.ch/Arcades_Manuals/Manuals/Arcades/After%20Burner%20Climax%20STD%20Manual.pdf))
Can't locate resolution about SDX (Super Deluxe cabinet) which has widescreen instead of 4:3 CRT.

**Ghost Squad Evolution**
640x480 ([US-DX & US-STD, p.54](https://segaretro.org/images/5/55/GhostSquadEvolution_Lindbergh_US_DigitalManual.pdf))

**Harley-Davidson: King of the Road manual**
1360x768 ([US, p.112](https://segaretro.org/images/9/93/HarleyDavidsonKotR_Lindbergh_US_DigitalManual.pdf))

**Hummer**
1280x768 ([US, p.130](https://segaretro.org/images/f/f0/Hummer_Lindbergh_DigitalManual_Serviceman.pdf))

**Hummer Extreme Edition**
(Missing) Unable to find information.

**Initial D Arcade Stage 4**
1360x768 ([US, p.78](https://segaretro.org/images/4/49/InitialD4_Lindbergh_Manual_Standard.pdf))

**Initial D Arcade Stage 5**
(Missing) Unable to find information.

**Let's Go Jungle!**
1360x768 ([US, p.44](https://segaretro.org/images/2/26/LetsGoJungle_Lindbergh_US_DigitalManual.pdf)) ([UK, p.113](https://segaretro.org/images/f/f2/LetsGoJungle_Lindbergh_Manual.pdf))

**Let's Go Jungle! Special**
(Incomplete) Unable to find information, but was confirmed by some owners that it was 1024x768 like HotD4S.

**OutRun 2 SP SDX**
800x480 ([US, p.170](https://store.playitamusements.com/assets/site/docs/manuals/outrun2specialtourssdx.pdf))

**Primeval Hunt**
640x480 ([US-Dual, p.60](https://archive.org/details/primeivilhuntmanual/page/n67/mode/2up)) ([UK-Single, p.99](https://segaretro.org/images/f/f3/PrimevalHunt_Lindbergh_UK_Manual_Standard.pdf))

**R-Tuned: Ultimate Street Racing**
640x480 ([US, p.93](https://archive.org/details/service_manual_sega_lindbergh/R-Tuned%20Manual.pdf))

**Rambo**
1360x768 ([US-STD, p.55](https://segaretro.org/images/6/62/Rambo_Lindbergh_US_Manual_Standard.pdf)) 
640x480 ([US-DLX, p. 104](https://archive.org/details/service_manual_sega_lindbergh/Rambo_DLX_Manual/page/103/mode/2up))

**Sega Race TV**
640x480 ([US-Single, p. 83](https://archive.org/details/service_manual_sega_lindbergh/Sega%20Race%20Tv%20Single%20Manual.pdf)) ([UK-Twin, p. 100](https://archive.org/details/service_manual_sega_lindbergh/SegaRaceTV/page/99/mode/2up))

**The House of the Dead 4**
640x480 and 1280x768 ([US, p.47](https://segaretro.org/images/1/1c/THotD4_Lindbergh_US_DigitalManual.pdf))

**The House of the Dead 4 Special**
1024x768 ([UK, p. 169](https://archive.org/details/the-house-of-the-dead-4-special/page/169/mode/2up))

**The House of the Dead EX**
(Missing) Unable to find information.

**Virtua Fighter 5 (all variants)**
(Incomplete) Unable to find information, but read in many old forums that res was 1280x768.

**Virtua Tennis 3**
640x480 and 1368x768 ([JP, p.3](https://segaretro.org/images/8/8e/Power_Smash_3_Lindbergh_JP_Manual.pdf)) ([US, p.3](https://www.manualslib.com/manual/2140267/Sega-Virtua-Tennis-3.html?page=6#manual))

Please help me verify missing and incomplete information before merging.

TL;DR:

![image](https://github.com/user-attachments/assets/7def9b5c-6a03-4620-9263-489e282da84d)